### PR TITLE
Change instances of NightwatchBot to Nightwatch in the docs

### DIFF
--- a/public/docs/classes/api.html
+++ b/public/docs/classes/api.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/api.ts#L30">api.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/api.ts#L30">api.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -147,7 +147,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/api.ts#L50">api.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/api.ts#L50">api.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/api.ts#L58">api.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/api.ts#L58">api.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/api.ts#L46">api.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/api.ts#L46">api.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/public/docs/classes/authenticationcontroller.html
+++ b/public/docs/classes/authenticationcontroller.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/authentication.ts#L15">controllers/authentication.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/authentication.ts#L15">controllers/authentication.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">authentication<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="authenticationservice.html" class="tsd-signature-type">AuthenticationService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/authentication.ts#L17">controllers/authentication.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/authentication.ts#L17">controllers/authentication.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">socket<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="socketservice.html" class="tsd-signature-type">SocketService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/authentication.ts#L18">controllers/authentication.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/authentication.ts#L18">controllers/authentication.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/authentication.ts#L27">controllers/authentication.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/authentication.ts#L27">controllers/authentication.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/public/docs/classes/authenticationservice.html
+++ b/public/docs/classes/authenticationservice.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/authentication.ts#L14">services/authentication.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/authentication.ts#L14">services/authentication.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/public/docs/classes/giveawaycontroller.html
+++ b/public/docs/classes/giveawaycontroller.html
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/giveaway.ts#L18">controllers/giveaway.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/giveaway.ts#L18">controllers/giveaway.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">giveaway<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="giveawayservice.html" class="tsd-signature-type">GiveawayService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/giveaway.ts#L20">controllers/giveaway.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/giveaway.ts#L20">controllers/giveaway.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">socket<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="socketservice.html" class="tsd-signature-type">SocketService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/giveaway.ts#L21">controllers/giveaway.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/giveaway.ts#L21">controllers/giveaway.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/giveaway.ts#L58">controllers/giveaway.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/giveaway.ts#L58">controllers/giveaway.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/giveaway.ts#L80">controllers/giveaway.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/giveaway.ts#L80">controllers/giveaway.ts:80</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/giveaway.ts#L45">controllers/giveaway.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/giveaway.ts#L45">controllers/giveaway.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/giveaway.ts#L32">controllers/giveaway.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/giveaway.ts#L32">controllers/giveaway.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -329,7 +329,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/giveaway.ts#L118">controllers/giveaway.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/giveaway.ts#L118">controllers/giveaway.ts:118</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -352,7 +352,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/giveaway.ts#L103">controllers/giveaway.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/giveaway.ts#L103">controllers/giveaway.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/public/docs/classes/giveawayservice.html
+++ b/public/docs/classes/giveawayservice.html
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">giveaway<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Giveaway</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(Giveaway)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/giveaway.ts#L14">services/giveaway.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/giveaway.ts#L14">services/giveaway.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/giveaway.ts#L24">services/giveaway.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/giveaway.ts#L24">services/giveaway.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/giveaway.ts#L33">services/giveaway.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/giveaway.ts#L33">services/giveaway.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -184,7 +184,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/giveaway.ts#L20">services/giveaway.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/giveaway.ts#L20">services/giveaway.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/giveaway.ts#L16">services/giveaway.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/giveaway.ts#L16">services/giveaway.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Giveaway</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/giveaway.ts#L29">services/giveaway.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/giveaway.ts#L29">services/giveaway.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/public/docs/classes/guildcontroller.html
+++ b/public/docs/classes/guildcontroller.html
@@ -150,7 +150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L18">controllers/guild.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L18">controllers/guild.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">guild<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="guildservice.html" class="tsd-signature-type">GuildService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L20">controllers/guild.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L20">controllers/guild.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">socket<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="socketservice.html" class="tsd-signature-type">SocketService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L21">controllers/guild.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L21">controllers/guild.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L58">controllers/guild.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L58">controllers/guild.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L155">controllers/guild.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L155">controllers/guild.ts:155</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L261">controllers/guild.ts:261</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L261">controllers/guild.ts:261</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -328,7 +328,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L402">controllers/guild.ts:402</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L402">controllers/guild.ts:402</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -372,7 +372,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L80">controllers/guild.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L80">controllers/guild.ts:80</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -410,7 +410,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L208">controllers/guild.ts:208</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L208">controllers/guild.ts:208</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -454,7 +454,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L313">controllers/guild.ts:313</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L313">controllers/guild.ts:313</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -498,7 +498,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L454">controllers/guild.ts:454</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L454">controllers/guild.ts:454</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -542,7 +542,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L45">controllers/guild.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L45">controllers/guild.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -580,7 +580,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L32">controllers/guild.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L32">controllers/guild.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -609,7 +609,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L338">controllers/guild.ts:338</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L338">controllers/guild.ts:338</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -647,7 +647,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L141">controllers/guild.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L141">controllers/guild.ts:141</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -691,7 +691,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L127">controllers/guild.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L127">controllers/guild.ts:127</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -729,7 +729,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L247">controllers/guild.ts:247</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L247">controllers/guild.ts:247</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -773,7 +773,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L233">controllers/guild.ts:233</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L233">controllers/guild.ts:233</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -811,7 +811,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L388">controllers/guild.ts:388</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L388">controllers/guild.ts:388</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -855,7 +855,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L374">controllers/guild.ts:374</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L374">controllers/guild.ts:374</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -893,7 +893,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L103">controllers/guild.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L103">controllers/guild.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -937,7 +937,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L352">controllers/guild.ts:352</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L352">controllers/guild.ts:352</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -981,7 +981,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L179">controllers/guild.ts:179</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L179">controllers/guild.ts:179</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1031,7 +1031,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L285">controllers/guild.ts:285</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L285">controllers/guild.ts:285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1081,7 +1081,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/guild.ts#L426">controllers/guild.ts:426</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/guild.ts#L426">controllers/guild.ts:426</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/public/docs/classes/guildservice.html
+++ b/public/docs/classes/guildservice.html
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">guild<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Guild</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(Guild)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L14">services/guild.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L14">services/guild.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">settings<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GuildSettings</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(GuildSettings)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L17">services/guild.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L17">services/guild.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">suggestion<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GuildSuggestion</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(GuildSuggestion)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L15">services/guild.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L15">services/guild.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">support<wbr>Ticket<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GuildSupportTicket</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(GuildSupportTicket)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L16">services/guild.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L16">services/guild.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GuildUser</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(GuildUser)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L18">services/guild.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L18">services/guild.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L30">services/guild.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L30">services/guild.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -222,7 +222,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L57">services/guild.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L57">services/guild.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -248,7 +248,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L84">services/guild.ts:84</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L84">services/guild.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -274,7 +274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L121">services/guild.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L121">services/guild.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L39">services/guild.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L39">services/guild.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -323,7 +323,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L62">services/guild.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L62">services/guild.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -349,7 +349,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L89">services/guild.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L89">services/guild.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L126">services/guild.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L126">services/guild.ts:126</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -401,7 +401,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L24">services/guild.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L24">services/guild.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -424,7 +424,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L20">services/guild.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L20">services/guild.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Guild</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -441,7 +441,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L103">services/guild.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L103">services/guild.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -464,7 +464,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L53">services/guild.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L53">services/guild.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -490,7 +490,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L49">services/guild.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L49">services/guild.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -513,7 +513,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L80">services/guild.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L80">services/guild.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -539,7 +539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L76">services/guild.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L76">services/guild.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -562,7 +562,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L115">services/guild.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L115">services/guild.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -588,7 +588,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L111">services/guild.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L111">services/guild.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -611,7 +611,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L35">services/guild.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L35">services/guild.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -637,7 +637,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L107">services/guild.ts:107</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L107">services/guild.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -663,7 +663,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L72">services/guild.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L72">services/guild.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -692,7 +692,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L99">services/guild.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L99">services/guild.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -721,7 +721,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/guild.ts#L138">services/guild.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/guild.ts#L138">services/guild.ts:138</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/public/docs/classes/referralcontroller.html
+++ b/public/docs/classes/referralcontroller.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/referral.ts#L18">controllers/referral.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/referral.ts#L18">controllers/referral.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">referral<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="referralservice.html" class="tsd-signature-type">ReferralService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/referral.ts#L20">controllers/referral.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/referral.ts#L20">controllers/referral.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">socket<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="socketservice.html" class="tsd-signature-type">SocketService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/referral.ts#L21">controllers/referral.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/referral.ts#L21">controllers/referral.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/referral.ts#L58">controllers/referral.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/referral.ts#L58">controllers/referral.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/referral.ts#L80">controllers/referral.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/referral.ts#L80">controllers/referral.ts:80</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -261,7 +261,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/referral.ts#L45">controllers/referral.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/referral.ts#L45">controllers/referral.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/referral.ts#L32">controllers/referral.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/referral.ts#L32">controllers/referral.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -328,7 +328,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/referral.ts#L103">controllers/referral.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/referral.ts#L103">controllers/referral.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/public/docs/classes/referralservice.html
+++ b/public/docs/classes/referralservice.html
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">referral<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Referral</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(Referral)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/referral.ts#L14">services/referral.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/referral.ts#L14">services/referral.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/referral.ts#L26">services/referral.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/referral.ts#L26">services/referral.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/referral.ts#L34">services/referral.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/referral.ts#L34">services/referral.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -184,7 +184,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/referral.ts#L20">services/referral.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/referral.ts#L20">services/referral.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/referral.ts#L16">services/referral.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/referral.ts#L16">services/referral.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Referral</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/referral.ts#L30">services/referral.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/referral.ts#L30">services/referral.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/public/docs/classes/socketservice.html
+++ b/public/docs/classes/socketservice.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/socket.ts#L12">services/socket.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/socket.ts#L12">services/socket.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/public/docs/classes/usercontroller.html
+++ b/public/docs/classes/usercontroller.html
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L27">controllers/user.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L27">controllers/user.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">socket<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="socketservice.html" class="tsd-signature-type">SocketService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L30">controllers/user.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L30">controllers/user.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<wbr>Service<span class="tsd-signature-symbol">:</span> <a href="userservice.html" class="tsd-signature-type">UserService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L29">controllers/user.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L29">controllers/user.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L67">controllers/user.ts:67</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L67">controllers/user.ts:67</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -230,7 +230,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L89">controllers/user.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L89">controllers/user.ts:89</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L54">controllers/user.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L54">controllers/user.ts:54</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -306,7 +306,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L41">controllers/user.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L41">controllers/user.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L240">controllers/user.ts:240</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L240">controllers/user.ts:240</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -372,7 +372,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L276">controllers/user.ts:276</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L276">controllers/user.ts:276</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -409,7 +409,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L189">controllers/user.ts:189</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L189">controllers/user.ts:189</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -465,7 +465,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L162">controllers/user.ts:162</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L162">controllers/user.ts:162</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -509,7 +509,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L112">controllers/user.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L112">controllers/user.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -553,7 +553,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L137">controllers/user.ts:137</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L137">controllers/user.ts:137</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -597,7 +597,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L254">controllers/user.ts:254</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L254">controllers/user.ts:254</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -641,7 +641,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/controllers/user.ts#L290">controllers/user.ts:290</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/controllers/user.ts#L290">controllers/user.ts:290</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/public/docs/classes/userservice.html
+++ b/public/docs/classes/userservice.html
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<wbr>Balance<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UserBalance</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(UserBalance)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L16">services/user.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L16">services/user.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<wbr>Level<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UserLevel</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(UserLevel)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L17">services/user.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L17">services/user.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<wbr>Profile<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UserProfile</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(UserProfile)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L18">services/user.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L18">services/user.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">User</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(User)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L15">services/user.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L15">services/user.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<wbr>Settings<wbr>Repository<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Repository</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UserSettings</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;getRepository(UserSettings)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L19">services/user.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L19">services/user.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L31">services/user.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L31">services/user.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -211,7 +211,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L40">services/user.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L40">services/user.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -234,7 +234,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L25">services/user.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L25">services/user.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -257,7 +257,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L21">services/user.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L21">services/user.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">User</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -274,7 +274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L77">services/user.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L77">services/user.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L89">services/user.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L89">services/user.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -320,7 +320,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L36">services/user.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L36">services/user.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -346,7 +346,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L73">services/user.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L73">services/user.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -372,7 +372,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L50">services/user.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L50">services/user.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -398,7 +398,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L81">services/user.ts:81</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L81">services/user.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -424,7 +424,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/user.ts#L85">services/user.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/user.ts#L85">services/user.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/public/docs/enums/resource.html
+++ b/public/docs/enums/resource.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ban<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ban&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L11">permissions/resource.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L11">permissions/resource.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bot<wbr>Role<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;botrole&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L4">permissions/resource.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L4">permissions/resource.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">Guild<wbr>Role<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;guildrole&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L3">permissions/resource.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L3">permissions/resource.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">Kick<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;kick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L10">permissions/resource.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L10">permissions/resource.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">Message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;message&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L2">permissions/resource.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L2">permissions/resource.ts:2</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mute<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;mute&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L8">permissions/resource.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L8">permissions/resource.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">Song<wbr>Request<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;songrequest&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L5">permissions/resource.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L5">permissions/resource.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">Text<wbr>Channel<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;textchannel&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L6">permissions/resource.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L6">permissions/resource.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">Voice<wbr>Channel<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;voicechannel&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L7">permissions/resource.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L7">permissions/resource.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">Warn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;warn&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/resource.ts#L9">permissions/resource.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/resource.ts#L9">permissions/resource.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/public/docs/enums/role.html
+++ b/public/docs/enums/role.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">Administrator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;administrator&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/role.ts#L6">permissions/role.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/role.ts#L6">permissions/role.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">DJ<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;dj&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/role.ts#L3">permissions/role.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/role.ts#L3">permissions/role.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">Member<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;member&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/role.ts#L2">permissions/role.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/role.ts#L2">permissions/role.ts:2</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">Moderator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;moderator&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/role.ts#L5">permissions/role.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/role.ts#L5">permissions/role.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">Muted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;muted&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/role.ts#L4">permissions/role.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/role.ts#L4">permissions/role.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/public/docs/globals.html
+++ b/public/docs/globals.html
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">access<wbr>Control<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AccessControl</span><span class="tsd-signature-symbol"> =&nbsp;new AccessControl()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/permissions/index.ts#L5">permissions/index.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/permissions/index.ts#L5">permissions/index.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">api<wbr>Server<wbr>Ip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/api.ts#L23">api.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/api.ts#L23">api.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">client<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/authentication.ts#L5">services/authentication.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/authentication.ts#L5">services/authentication.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">client<wbr>Secret<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/services/authentication.ts#L5">services/authentication.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/services/authentication.ts#L5">services/authentication.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">container<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Container</span><span class="tsd-signature-symbol"> =&nbsp;new Container()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/ioc/ioc.ts#L3">ioc/ioc.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/ioc/ioc.ts#L3">ioc/ioc.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,8 +195,8 @@
 					<div class="tsd-signature tsd-kind-icon">debug<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> =&nbsp;require(&#x27;debug&#x27;)(&#x27;express:server&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/api.ts#L23">api.ts:23</a></li>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/index.ts#L4">index.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/api.ts#L23">api.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/index.ts#L4">index.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">env<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;process.env.NODE_ENV || &#x27;development&#x27;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/config/index.ts#L9">config/index.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/config/index.ts#L9">config/index.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">fluent<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span><span class="tsd-signature-symbol"> =&nbsp;makeFluentProvideDecorator(container)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/ioc/ioc.ts#L6">ioc/ioc.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/ioc/ioc.ts#L6">ioc/ioc.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -247,7 +247,7 @@
 					<div class="tsd-signature tsd-kind-icon">io<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Server</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/utilities/socket.ts#L4">utilities/socket.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/utilities/socket.ts#L4">utilities/socket.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Prod<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> =&nbsp;env &#x3D;&#x3D;&#x3D; &#x27;production&#x27;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/config/index.ts#L10">config/index.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/config/index.ts#L10">config/index.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -267,7 +267,7 @@
 					<div class="tsd-signature tsd-kind-icon">mongodb<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/api.ts#L23">api.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/api.ts#L23">api.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -277,7 +277,7 @@
 					<div class="tsd-signature tsd-kind-icon">process<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/config/index.ts#L3">config/index.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/config/index.ts#L3">config/index.ts:3</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -300,7 +300,7 @@
 					<div class="tsd-signature tsd-kind-icon">provide<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span><span class="tsd-signature-symbol"> =&nbsp;makeProvideDecorator(container)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/ioc/ioc.ts#L5">ioc/ioc.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/ioc/ioc.ts#L5">ioc/ioc.ts:5</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -352,7 +352,7 @@
 					<div class="tsd-signature tsd-kind-icon">secret<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/api.ts#L23">api.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/api.ts#L23">api.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -362,7 +362,7 @@
 					<div class="tsd-signature tsd-kind-icon">server<span class="tsd-signature-symbol">:</span> <a href="classes/api.html" class="tsd-signature-type">Api</a><span class="tsd-signature-symbol"> =&nbsp;Api.start()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/index.ts#L6">index.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/index.ts#L6">index.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -379,7 +379,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/utilities/socket.ts#L14">utilities/socket.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/utilities/socket.ts#L14">utilities/socket.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Server</span></h4>
@@ -396,7 +396,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/utilities/socket.ts#L6">utilities/socket.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/utilities/socket.ts#L6">utilities/socket.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -419,7 +419,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/ioc/ioc.ts#L8">ioc/ioc.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/ioc/ioc.ts#L8">ioc/ioc.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -462,7 +462,7 @@
 					<div class="tsd-signature tsd-kind-icon">Events<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L1">constants/events.ts:1</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L1">constants/events.ts:1</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -471,7 +471,7 @@
 						<div class="tsd-signature tsd-kind-icon">info<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;info&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L42">constants/events.ts:42</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L42">constants/events.ts:42</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -481,7 +481,7 @@
 						<div class="tsd-signature tsd-kind-icon">giveaway<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L32">constants/events.ts:32</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L32">constants/events.ts:32</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -490,7 +490,7 @@
 							<div class="tsd-signature tsd-kind-icon">created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;giveawayCreated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L33">constants/events.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L33">constants/events.ts:33</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -500,7 +500,7 @@
 							<div class="tsd-signature tsd-kind-icon">deleted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;giveawayCreated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L34">constants/events.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L34">constants/events.ts:34</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -510,7 +510,7 @@
 							<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;giveawayCreated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L35">constants/events.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L35">constants/events.ts:35</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -521,7 +521,7 @@
 						<div class="tsd-signature tsd-kind-icon">guild<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L11">constants/events.ts:11</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L11">constants/events.ts:11</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -530,7 +530,7 @@
 							<div class="tsd-signature tsd-kind-icon">created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildCreated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L12">constants/events.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L12">constants/events.ts:12</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -540,7 +540,7 @@
 							<div class="tsd-signature tsd-kind-icon">deleted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildDeleted&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L13">constants/events.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L13">constants/events.ts:13</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -550,7 +550,7 @@
 							<div class="tsd-signature tsd-kind-icon">settings<wbr>Updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildSettingsUpdated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L25">constants/events.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L25">constants/events.ts:25</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -560,7 +560,7 @@
 							<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildUpdated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L14">constants/events.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L14">constants/events.ts:14</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -570,7 +570,7 @@
 							<div class="tsd-signature tsd-kind-icon">suggestion<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L15">constants/events.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L15">constants/events.ts:15</a></li>
 								</ul>
 							</aside>
 							<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -579,7 +579,7 @@
 								<div class="tsd-signature tsd-kind-icon">created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildSuggestionCreated&quot;</span></div>
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L16">constants/events.ts:16</a></li>
+										<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L16">constants/events.ts:16</a></li>
 									</ul>
 								</aside>
 							</section>
@@ -589,7 +589,7 @@
 								<div class="tsd-signature tsd-kind-icon">deleted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildSuggestionDeleted&quot;</span></div>
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L18">constants/events.ts:18</a></li>
+										<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L18">constants/events.ts:18</a></li>
 									</ul>
 								</aside>
 							</section>
@@ -599,7 +599,7 @@
 								<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildSuggestionUpdated&quot;</span></div>
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L17">constants/events.ts:17</a></li>
+										<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L17">constants/events.ts:17</a></li>
 									</ul>
 								</aside>
 							</section>
@@ -610,7 +610,7 @@
 							<div class="tsd-signature tsd-kind-icon">support<wbr>Ticket<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L20">constants/events.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L20">constants/events.ts:20</a></li>
 								</ul>
 							</aside>
 							<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -619,7 +619,7 @@
 								<div class="tsd-signature tsd-kind-icon">created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildSupportTicketCreated&quot;</span></div>
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L21">constants/events.ts:21</a></li>
+										<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L21">constants/events.ts:21</a></li>
 									</ul>
 								</aside>
 							</section>
@@ -629,7 +629,7 @@
 								<div class="tsd-signature tsd-kind-icon">deleted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildSupportTicketDeleted&quot;</span></div>
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L23">constants/events.ts:23</a></li>
+										<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L23">constants/events.ts:23</a></li>
 									</ul>
 								</aside>
 							</section>
@@ -639,7 +639,7 @@
 								<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildSupportTicketUpdated&quot;</span></div>
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L22">constants/events.ts:22</a></li>
+										<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L22">constants/events.ts:22</a></li>
 									</ul>
 								</aside>
 							</section>
@@ -650,7 +650,7 @@
 							<div class="tsd-signature tsd-kind-icon">user<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L26">constants/events.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L26">constants/events.ts:26</a></li>
 								</ul>
 							</aside>
 							<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -659,7 +659,7 @@
 								<div class="tsd-signature tsd-kind-icon">created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildUserCreated&quot;</span></div>
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L27">constants/events.ts:27</a></li>
+										<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L27">constants/events.ts:27</a></li>
 									</ul>
 								</aside>
 							</section>
@@ -669,7 +669,7 @@
 								<div class="tsd-signature tsd-kind-icon">deleted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildUserDeleted&quot;</span></div>
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L28">constants/events.ts:28</a></li>
+										<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L28">constants/events.ts:28</a></li>
 									</ul>
 								</aside>
 							</section>
@@ -679,7 +679,7 @@
 								<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;guildUserUpdated&quot;</span></div>
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L29">constants/events.ts:29</a></li>
+										<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L29">constants/events.ts:29</a></li>
 									</ul>
 								</aside>
 							</section>
@@ -691,7 +691,7 @@
 						<div class="tsd-signature tsd-kind-icon">referral<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L37">constants/events.ts:37</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L37">constants/events.ts:37</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -700,7 +700,7 @@
 							<div class="tsd-signature tsd-kind-icon">created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;referralCreated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L38">constants/events.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L38">constants/events.ts:38</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -710,7 +710,7 @@
 							<div class="tsd-signature tsd-kind-icon">deleted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;referralDeleted&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L39">constants/events.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L39">constants/events.ts:39</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -720,7 +720,7 @@
 							<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;referralUpdated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L40">constants/events.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L40">constants/events.ts:40</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -731,7 +731,7 @@
 						<div class="tsd-signature tsd-kind-icon">user<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L2">constants/events.ts:2</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L2">constants/events.ts:2</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -740,7 +740,7 @@
 							<div class="tsd-signature tsd-kind-icon">balance<wbr>Updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;userBalanceUpdated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L7">constants/events.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L7">constants/events.ts:7</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -750,7 +750,7 @@
 							<div class="tsd-signature tsd-kind-icon">created<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;userCreated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L3">constants/events.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L3">constants/events.ts:3</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -760,7 +760,7 @@
 							<div class="tsd-signature tsd-kind-icon">deleted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;userDeleted&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L4">constants/events.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L4">constants/events.ts:4</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -770,7 +770,7 @@
 							<div class="tsd-signature tsd-kind-icon">level<wbr>Updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;userLevelUpdated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L6">constants/events.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L6">constants/events.ts:6</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -780,7 +780,7 @@
 							<div class="tsd-signature tsd-kind-icon">profile<wbr>Updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;userProfileUpdated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L8">constants/events.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L8">constants/events.ts:8</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -790,7 +790,7 @@
 							<div class="tsd-signature tsd-kind-icon">settings<wbr>Updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;userSettingsUpdated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L9">constants/events.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L9">constants/events.ts:9</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -800,7 +800,7 @@
 							<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;userUpdated&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/events.ts#L5">constants/events.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/events.ts#L5">constants/events.ts:5</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -812,7 +812,7 @@
 					<div class="tsd-signature tsd-kind-icon">Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/types.ts#L1">constants/types.ts:1</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/types.ts#L1">constants/types.ts:1</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -821,7 +821,7 @@
 						<div class="tsd-signature tsd-kind-icon">Authentication<wbr>Service<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol(&#x27;AuthenticationService&#x27;)</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/types.ts#L2">constants/types.ts:2</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/types.ts#L2">constants/types.ts:2</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -831,7 +831,7 @@
 						<div class="tsd-signature tsd-kind-icon">Config<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol(&#x27;ConfigProvider&#x27;)</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/types.ts#L9">constants/types.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/types.ts#L9">constants/types.ts:9</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -841,7 +841,7 @@
 						<div class="tsd-signature tsd-kind-icon">Database<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol(&#x27;DatabaseProvider&#x27;)</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/types.ts#L8">constants/types.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/types.ts#L8">constants/types.ts:8</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -851,7 +851,7 @@
 						<div class="tsd-signature tsd-kind-icon">Giveaway<wbr>Service<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol(&#x27;GiveawayService&#x27;)</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/types.ts#L5">constants/types.ts:5</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/types.ts#L5">constants/types.ts:5</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -861,7 +861,7 @@
 						<div class="tsd-signature tsd-kind-icon">Guild<wbr>Service<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol(&#x27;GuildService&#x27;)</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/types.ts#L4">constants/types.ts:4</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/types.ts#L4">constants/types.ts:4</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -871,7 +871,7 @@
 						<div class="tsd-signature tsd-kind-icon">Referral<wbr>Service<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol(&#x27;ReferralService&#x27;)</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/types.ts#L6">constants/types.ts:6</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/types.ts#L6">constants/types.ts:6</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -881,7 +881,7 @@
 						<div class="tsd-signature tsd-kind-icon">Socket<wbr>Service<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol(&#x27;SocketService&#x27;)</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/types.ts#L7">constants/types.ts:7</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/types.ts#L7">constants/types.ts:7</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -891,7 +891,7 @@
 						<div class="tsd-signature tsd-kind-icon">User<wbr>Service<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol(&#x27;UserService&#x27;)</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/constants/types.ts#L3">constants/types.ts:3</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/constants/types.ts#L3">constants/types.ts:3</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -902,7 +902,7 @@
 					<div class="tsd-signature tsd-kind-icon">config<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/config/index.ts#L12">config/index.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/config/index.ts#L12">config/index.ts:12</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -911,7 +911,7 @@
 						<div class="tsd-signature tsd-kind-icon">env<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"dev"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"prod"</span><span class="tsd-signature-symbol"> =&nbsp;isProd ? &#x27;prod&#x27; : &#x27;dev&#x27;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/config/index.ts#L15">config/index.ts:15</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/config/index.ts#L15">config/index.ts:15</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -921,7 +921,7 @@
 						<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;api&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/config/index.ts#L13">config/index.ts:13</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/config/index.ts#L13">config/index.ts:13</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -931,7 +931,7 @@
 						<div class="tsd-signature tsd-kind-icon">port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;isProd ? 5000 : 3001</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/config/index.ts#L14">config/index.ts:14</a></li>
+								<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/config/index.ts#L14">config/index.ts:14</a></li>
 							</ul>
 						</aside>
 					</section>

--- a/public/docs/interfaces/basecontroller.html
+++ b/public/docs/interfaces/basecontroller.html
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">create<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseController.ts#L6">interfaces/BaseController.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseController.ts#L6">interfaces/BaseController.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">delete<wbr>ById<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseController.ts#L8">interfaces/BaseController.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseController.ts#L8">interfaces/BaseController.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">find<wbr>ById<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseController.ts#L5">interfaces/BaseController.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseController.ts#L5">interfaces/BaseController.ts:5</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>All<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseController.ts#L4">interfaces/BaseController.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseController.ts#L4">interfaces/BaseController.ts:4</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -259,7 +259,7 @@
 					<div class="tsd-signature tsd-kind-icon">update<wbr>ById<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseController.ts#L7">interfaces/BaseController.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseController.ts#L7">interfaces/BaseController.ts:7</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/public/docs/interfaces/baseservice.html
+++ b/public/docs/interfaces/baseservice.html
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">create<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseService.ts#L4">interfaces/BaseService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseService.ts#L4">interfaces/BaseService.ts:4</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">delete<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseService.ts#L6">interfaces/BaseService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseService.ts#L6">interfaces/BaseService.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">find<wbr>ById<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseService.ts#L3">interfaces/BaseService.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseService.ts#L3">interfaces/BaseService.ts:3</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -207,7 +207,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>All<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseService.ts#L2">interfaces/BaseService.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseService.ts#L2">interfaces/BaseService.ts:2</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">update<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/interfaces/BaseService.ts#L5">interfaces/BaseService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/interfaces/BaseService.ts#L5">interfaces/BaseService.ts:5</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/public/docs/interfaces/config.html
+++ b/public/docs/interfaces/config.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">env<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"dev"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"prod"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/models/config.model.ts#L22">models/config.model.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/models/config.model.ts#L22">models/config.model.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/models/config.model.ts#L8">models/config.model.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/models/config.model.ts#L8">models/config.model.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/models/config.model.ts#L15">models/config.model.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/models/config.model.ts#L15">models/config.model.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/models/config.model.ts#L29">models/config.model.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/models/config.model.ts#L29">models/config.model.ts:29</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/public/docs/interfaces/userlevelbalance.html
+++ b/public/docs/interfaces/userlevelbalance.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">UserBalance</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/models/userLevelBalance.model.ts#L5">models/userLevelBalance.model.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/models/userLevelBalance.model.ts#L5">models/userLevelBalance.model.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">level<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">UserLevel</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/NightwatchBot/api/blob/2b533c3/src/models/userLevelBalance.model.ts#L4">models/userLevelBalance.model.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/Nightwatch/api/blob/2b533c3/src/models/userLevelBalance.model.ts#L4">models/userLevelBalance.model.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>


### PR DESCRIPTION
Just for consistency and in case someone makes an account called NightwatchBot and makes a repo called api.